### PR TITLE
Wait to start runtime until 'configurationDone'

### DIFF
--- a/src/mockDebug.ts
+++ b/src/mockDebug.ts
@@ -37,6 +37,7 @@ class MockDebugSession extends LoggingDebugSession {
 	private _runtime: MockRuntime;
 
 	private _launchArgs: LaunchRequestArguments;
+	private _isConfigurationDone:boolean = false;
 
 	private _variableHandles = new Handles<string>();
 
@@ -112,15 +113,26 @@ class MockDebugSession extends LoggingDebugSession {
 		// make sure to 'Stop' the buffered logging if 'trace' is not set
 		logger.setup(args.trace ? Logger.LogLevel.Verbose : Logger.LogLevel.Stop, false);
 
-		this._launchArgs = args;
+		if (this._isConfigurationDone) {
+			// Configuration is done, start the runtime
+			this.startRuntime(args);
+		} else {
+			// Configuration hasn't finished - save the args for later
+			this._launchArgs = args;
+		}
 
 		this.sendResponse(response);
 	}
 
 	protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments): void {
 
-		// Now that we've received all breakpoints, etc, start the program in the runtime
-		this._runtime.start(this._launchArgs.program, !!this._launchArgs.stopOnEntry);
+		this._isConfigurationDone = true;
+		if (this._launchArgs != null) {
+			// If we received a launch request before finishing configuration, start the runtime using the cached arguments now
+			this._runtime.start(this._launchArgs.program, !!this._launchArgs.stopOnEntry);
+		}
+
+		this.sendResponse(response);
 	}
 
 	protected setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments): void {
@@ -280,6 +292,10 @@ class MockDebugSession extends LoggingDebugSession {
 
 	private createSource(filePath: string): Source {
 		return new Source(basename(filePath), this.convertDebuggerPathToClient(filePath), undefined, undefined, 'mock-adapter-data');
+	}
+
+	private startRuntime(launchArgs: LaunchRequestArguments) {
+		this._runtime.start(launchArgs.program, !!launchArgs.stopOnEntry);
 	}
 }
 

--- a/src/mockDebug.ts
+++ b/src/mockDebug.ts
@@ -36,6 +36,8 @@ class MockDebugSession extends LoggingDebugSession {
 	// a Mock runtime (or debugger)
 	private _runtime: MockRuntime;
 
+	private _launchArgs: LaunchRequestArguments;
+
 	private _variableHandles = new Handles<string>();
 
 	/**
@@ -110,10 +112,15 @@ class MockDebugSession extends LoggingDebugSession {
 		// make sure to 'Stop' the buffered logging if 'trace' is not set
 		logger.setup(args.trace ? Logger.LogLevel.Verbose : Logger.LogLevel.Stop, false);
 
-		// start the program in the runtime
-		this._runtime.start(args.program, !!args.stopOnEntry);
+		this._launchArgs = args;
 
 		this.sendResponse(response);
+	}
+
+	protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments): void {
+
+		// Now that we've received all breakpoints, etc, start the program in the runtime
+		this._runtime.start(this._launchArgs.program, !!this._launchArgs.stopOnEntry);
 	}
 
 	protected setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments): void {

--- a/src/tests/adapter.test.ts
+++ b/src/tests/adapter.test.ts
@@ -68,8 +68,9 @@ suite('Node Debug Adapter', () => {
 			const PROGRAM = Path.join(DATA_ROOT, 'test.md');
 
 			return Promise.all([
-				dc.configurationSequence(),
-				dc.launch({ program: PROGRAM }),
+				dc.launch({ program: PROGRAM, trace: true }).then(response => {
+					dc.configurationDoneRequest();
+				}),
 				dc.waitForEvent('terminated')
 			]);
 		});
@@ -80,8 +81,9 @@ suite('Node Debug Adapter', () => {
 			const ENTRY_LINE = 1;
 
 			return Promise.all([
-				dc.configurationSequence(),
-				dc.launch({ program: PROGRAM, stopOnEntry: true }),
+				dc.launch({ program: PROGRAM, stopOnEntry: true }).then(response => {
+					dc.configurationDoneRequest();
+				}),
 				dc.assertStoppedLocation('entry', { line: ENTRY_LINE } )
 			]);
 		});


### PR DESCRIPTION
The mock debug engine currently starts the runtime as soon as a `launch` request is received.  This can cause problems such as missed breakpoints if configuration is not yet complete.  This commit changes the logic so that the runtime will not actually begin execution until the `configurationDone` message is received from the host.

@weinand 