### PR TITLE
fix #43 Smarter handling of run and debug commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,17 +77,31 @@
 					"when": "resourceLangId == markdown",
 					"group": "run@20"
 				}
+			],
+			"commandPalette": [
+				{
+					"command": "extension.mock-debug.debugEditorContents",
+					"when": "resourceLangId == markdown"
+				},
+				{
+					"command": "extension.mock-debug.runEditorContents",
+					"when": "resourceLangId == markdown"
+				}
 			]
 		},
 		"commands": [
 			{
 				"command": "extension.mock-debug.debugEditorContents",
 				"title": "Debug Editor Contents",
+				"category": "Mock Debug",
+				"enablement": "!inDebugMode",
 				"icon": "$(debug-alt)"
 			},
 			{
 				"command": "extension.mock-debug.runEditorContents",
 				"title": "Run Editor Contents",
+				"category": "Mock Debug",
+				"enablement": "!inDebugMode",
 				"icon": "$(play)"
 			}
 		],

--- a/package.json
+++ b/package.json
@@ -92,14 +92,14 @@
 		"commands": [
 			{
 				"command": "extension.mock-debug.debugEditorContents",
-				"title": "Debug Editor Contents",
+				"title": "Debug File",
 				"category": "Mock Debug",
 				"enablement": "!inDebugMode",
 				"icon": "$(debug-alt)"
 			},
 			{
 				"command": "extension.mock-debug.runEditorContents",
-				"title": "Run Editor Contents",
+				"title": "Run File",
 				"category": "Mock Debug",
 				"enablement": "!inDebugMode",
 				"icon": "$(play)"

--- a/package.json
+++ b/package.json
@@ -70,12 +70,12 @@
 				{
 					"command": "extension.mock-debug.runEditorContents",
 					"when": "resourceLangId == markdown",
-					"group": "navigation@-2"
+					"group": "run@10"
 				},
 				{
 					"command": "extension.mock-debug.debugEditorContents",
 					"when": "resourceLangId == markdown",
-					"group": "navigation@-1"
+					"group": "run@20"
 				}
 			]
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
 			if (targetResource) {
 				vscode.debug.startDebugging(undefined, {
 					type: 'mock',
-					name: 'Run Editor Contents',
+					name: 'Run File',
 					request: 'launch',
 					program: targetResource.fsPath,
 					noDebug: true
@@ -45,7 +45,7 @@ export function activate(context: vscode.ExtensionContext) {
 			if (targetResource) {
 				vscode.debug.startDebugging(undefined, {
 					type: 'mock',
-					name: 'Debug Editor Contents',
+					name: 'Debug File',
 					request: 'launch',
 					program: targetResource.fsPath
 				});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,26 +18,38 @@ const runMode: 'external' | 'server' | 'inline' = 'inline';
 export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand('extension.mock-debug.runEditorContents', (resource: vscode.Uri) => {
-			vscode.debug.startDebugging(undefined, {
-				type: 'mock',
-				name: 'Run Editor Contents',
-				request: 'launch',
-				program: resource.fsPath,
-				noDebug: true
-			},/* upcoming proposed API:
-				{
+		vscode.commands.registerCommand('extension.mock-debug.runEditorContents', (resource: vscode.Uri | undefined) => {
+			let targetResource = resource;
+			if (!targetResource && vscode.window.activeTextEditor) {
+				targetResource = vscode.window.activeTextEditor.document.uri;
+			}
+			if (targetResource) {
+				vscode.debug.startDebugging(undefined, {
+					type: 'mock',
+					name: 'Run Editor Contents',
+					request: 'launch',
+					program: targetResource.fsPath,
 					noDebug: true
+				},/* upcoming proposed API:
+					{
+						noDebug: true
+					}
+				*/);
 				}
-			*/);
 		}),
-		vscode.commands.registerCommand('extension.mock-debug.debugEditorContents', (resource: vscode.Uri) => {
-			vscode.debug.startDebugging(undefined, {
-				type: 'mock',
-				name: 'Debug Editor Contents',
-				request: 'launch',
-				program: resource.fsPath
-			});
+		vscode.commands.registerCommand('extension.mock-debug.debugEditorContents', (resource: vscode.Uri | undefined) => {
+			let targetResource = resource;
+			if (!targetResource && vscode.window.activeTextEditor) {
+				targetResource = vscode.window.activeTextEditor.document.uri;
+			}
+			if (targetResource) {
+				vscode.debug.startDebugging(undefined, {
+					type: 'mock',
+					name: 'Debug Editor Contents',
+					request: 'launch',
+					program: targetResource.fsPath
+				});
+			}
 		})
 	);
 


### PR DESCRIPTION
This PR fixes #43 

The debug and run commands are now assigned to "Mock Debug" group so they get prefixed in Command Palette.

They only appear there if there is a suitable active document.

They can be run from the Command Palette or from a user-specified keybinding.

Their editor command buttons get disabled when debugging is active.