### PR TITLE
Add DebugAdapterNamedPipeServer factory

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,16 +4,20 @@
 
 'use strict';
 
+import * as Net from 'net';
 import * as vscode from 'vscode';
+import { randomBytes } from 'crypto';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { platform } from 'process';
 import { WorkspaceFolder, DebugConfiguration, ProviderResult, CancellationToken } from 'vscode';
 import { MockDebugSession } from './mockDebug';
-import * as Net from 'net';
 
 /*
  * The compile time flag 'runMode' controls how the debug adapter is run.
  * Please note: the test suite only supports 'external' mode.
  */
-const runMode: 'external' | 'server' | 'inline' = 'inline';
+const runMode: 'external' | 'server' | 'namedPipeServer' | 'inline' = 'inline';
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -83,7 +87,12 @@ export function activate(context: vscode.ExtensionContext) {
 	switch (runMode) {
 		case 'server':
 			// run the debug adapter as a server inside the extension and communicating via a socket
-			factory = new MockDebugAdapterDescriptorFactory();
+			factory = new MockDebugAdapterServerDescriptorFactory();
+			break;
+
+		case 'namedPipeServer':
+			// run the debug adapter as a server inside the extension and communicating via a named pipe (Windows)/UNIX domain socket (non-Windows)
+			factory = new MockDebugAdapterNamedPipeServerDescriptorFactory();
 			break;
 
 		case 'inline':
@@ -174,7 +183,7 @@ class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescriptorFact
 	}
 }
 
-class MockDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
+class MockDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
 
 	private server?: Net.Server;
 
@@ -191,6 +200,35 @@ class MockDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptor
 
 		// make VS Code connect to debug server
 		return new vscode.DebugAdapterServer((<Net.AddressInfo>this.server.address()).port);
+	}
+
+	dispose() {
+		if (this.server) {
+			this.server.close();
+		}
+	}
+}
+
+class MockDebugAdapterNamedPipeServerDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
+
+	private server?: Net.Server;
+
+	createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+
+		if (!this.server) {
+			// start listening on a random named pipe path
+			const pipeName = randomBytes(10).toString('utf8');
+			const pipePath = platform === "win32" ? join('\\\\.\\pipe\\', pipeName) : join(tmpdir(), pipeName);
+
+			this.server = Net.createServer(socket => {
+				const session = new MockDebugSession();
+				session.setRunAsServer(true);
+				session.start(<NodeJS.ReadableStream>socket, socket);
+			}).listen(pipePath);
+		}
+
+		// make VS Code connect to debug server
+		return new vscode.DebugAdapterNamedPipeServer(this.server.address() as string);
 	}
 
 	dispose() {


### PR DESCRIPTION
This adds the new DebugAdapter descriptor, `DebugAdapterNamedPipeServer`, Added in https://github.com/microsoft/vscode/pull/103210.

This will fail to compile until that is in and released via `@types/vscode` so I'll leave it as a Draft PR.

I tested this by:
* Opening vscode-mock-debug in my local build of vscode that has `DebugAdapterNamedPipeServer` available
* Changing `runMode` to the added `namedPipeServer`
* Debugging a `readme.md` file

Let me know if there are tests I should add for this.