### PR TITLE
Added "compile" as a pre launch task for "Server" run config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,8 @@
 			],
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
-			]
+			],
+			"preLaunchTask": "npm: compile"
 		},
 		{
 			"name": "Tests",


### PR DESCRIPTION
Added `npm: compile` as a `preLaunchTask` for the **Server** run configuration. Otherwise invoking the **Server** run configuration results in the following syntax error.
```
import { MockDebugSession } from './mockDebug';
^^^^^^

SyntaxError: Cannot use import statement outside a module
```