### PR TITLE
Modify test.md and mockDebug to test DataBreakpoint access types

### DIFF
--- a/sampleWorkspace/test.md
+++ b/sampleWorkspace/test.md
@@ -23,6 +23,27 @@ If a Mock Debug session is active, breakpoints are "validated" according these r
 * if a line starts with `-` we don't allow to set a breakpoint but move the breakpoint up
 * a breakpoint on a line containing the word `lazy` is not immediately validated, but only after hitting it once.
 
+## Data Breakpoints
+
+Data Breakpoints can be set in the VARIABLES view of the editor (while debugging) if the Debug Session supports these.
+Breakpoint should apply on next line if access type is "Read" (Break When Value Is Read)
+* local_i_read 
+* local_f_read 
+* local_s_read 
+* local_o_read
+
+Breakpoint should apply on next line if access type is "Write" (Break When Value Changes)
+* local_i_write 
+* local_f_write 
+* local_s_write 
+* local_o_write
+
+Breakpoint should apply on next line if access type is "ReadWrite" (Break When Value Is Accessed)
+* local_i_readWrite 
+* local_f_readWrite 
+* local_s_readWrite 
+* local_o_readWrite
+
 ## Exceptions:
 
 If a line contains the word `exception` or the pattern `exception(name)` an exception is thrown.

--- a/src/mockDebug.ts
+++ b/src/mockDebug.ts
@@ -550,7 +550,12 @@ export class MockDebugSession extends LoggingDebugSession {
 			if (id === "global") {
 				response.body.dataId = args.name;
 				response.body.description = args.name;
-				response.body.accessTypes = [ "read" ];
+				response.body.accessTypes = [ "write" ];
+				response.body.canPersist = true;
+			} else {
+				response.body.dataId = args.name;
+				response.body.description = args.name;
+				response.body.accessTypes = ["read", "write", "readWrite"];
 				response.body.canPersist = true;
 			}
 		}
@@ -569,7 +574,8 @@ export class MockDebugSession extends LoggingDebugSession {
 
 		for (const dbp of args.breakpoints) {
 			// assume that id is the "address" to break on
-			const ok = this._runtime.setDataBreakpoint(dbp.dataId);
+			const dataId = dbp.dataId + `_${dbp.accessType ? dbp.accessType : 'write'}`
+			const ok = this._runtime.setDataBreakpoint(dataId);
 			response.body.breakpoints.push({
 				verified: ok
 			});


### PR DESCRIPTION
Hi
According to this test suite : https://github.com/microsoft/vscode/issues/119197
I did modify test.md and mockDebug to test access types.
I support here `read` and `readWrite`. Tell me if you don't see any side-effects to use `write` as well, or if it is enough.

Thanks.