### PR TITLE
Fix running adapter in external mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,9 @@
     "esbuild-base": "esbuild ./src/extension.ts --bundle --tsconfig=./tsconfig.json --external:vscode --format=cjs --platform=node --outfile=dist/extension.js",
     "watch": "npm run -S esbuild-base -- --sourcemap --sources-content=false --watch",
     "esbuild-web": "esbuild ./src/web-extension.ts --bundle --tsconfig=./tsconfig.json --external:vscode --format=cjs --platform=browser --outfile=dist/web-extension.js",
+    "esbuild-adapter": "esbuild ./src/debugAdapter.ts --bundle --tsconfig=./tsconfig.json --external:vscode --format=cjs --platform=node --outfile=dist/debugAdapter.js",
     "watch-web": "npm run -S esbuild-web -- --sourcemap --sources-content=false --watch",
-    "build": "npm run -S esbuild-base -- --sourcemap --sources-content=false && npm run -S esbuild-web -- --sourcemap --sources-content=false",
+    "build": "npm run -S esbuild-base -- --sourcemap --sources-content=false && npm run -S esbuild-web -- --sourcemap --sources-content=false && npm run -S esbuild-adapter -- --sourcemap --sources-content=false",
     "package": "vsce package",
     "publish": "vsce publish",
     "publish-pre-release": "vsce publish --pre-release",
@@ -136,7 +137,7 @@
           "markdown"
         ],
         "label": "Mock Debug",
-        "program": "./out/debugAdapter.js",
+        "program": "./dist/debugAdapter.js",
         "runtime": "node",
         "configurationAttributes": {
           "launch": {

--- a/src/tests/adapter.test.ts
+++ b/src/tests/adapter.test.ts
@@ -10,7 +10,7 @@ import {DebugProtocol} from '@vscode/debugprotocol';
 
 suite('Node Debug Adapter', () => {
 
-	const DEBUG_ADAPTER = './out/debugAdapter.js';
+	const DEBUG_ADAPTER = './dist/debugAdapter.js';
 
 	const PROJECT_ROOT = Path.join(__dirname, '../../');
 	const DATA_ROOT = Path.join(PROJECT_ROOT, 'src/tests/data/');


### PR DESCRIPTION
Without these changes, the debug adapter fails to start in `"external"` mode. It seems to be because it never gets compiled - my guess is that at some point the compilation was changed (things go into `dist/` now, but it looks in `out/` for the DA) but it was overlooked.

This adds a new command to build the adapter into `dist/debugAdapter.js`, adds it to the main build command, and updates the definition in `package.json`.

I don't know if anything else needs doing, but this seems to solve the problem in my (admittedly basic) testing.